### PR TITLE
Batch order bug fix and config fix

### DIFF
--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -268,7 +268,7 @@ func (r *configReader) createIndexes() {
 	r.cctpDomainIndex = make(map[ChainEnvironment]map[uint32]ChainConfig)
 	r.chainIDIndex = make(map[string]ChainConfig)
 
-	for chainID, chain := range r.config.Chains {
+	for _, chain := range r.config.Chains {
 		if _, ok := r.cctpDomainIndex[chain.Environment]; !ok {
 			r.cctpDomainIndex[chain.Environment] = make(map[uint32]ChainConfig)
 		}
@@ -277,7 +277,7 @@ func (r *configReader) createIndexes() {
 		if chain.Type == ChainType_COSMOS && chain.Cosmos == nil {
 			lmt.Logger(context.Background()).Error(
 				"invalid chain configuration",
-				zap.String("chainID", chainID),
+				zap.String("chainID", chain.ChainID),
 				zap.String("type", string(chain.Type)),
 				zap.Bool("hasCosmosConfig", chain.Cosmos != nil),
 			)
@@ -286,17 +286,17 @@ func (r *configReader) createIndexes() {
 		if chain.Type == ChainType_EVM && chain.EVM == nil {
 			lmt.Logger(context.Background()).Error(
 				"invalid chain configuration",
-				zap.String("chainID", chainID),
+				zap.String("chainID", chain.ChainID),
 				zap.String("type", string(chain.Type)),
 				zap.Bool("hasEVMConfig", chain.EVM != nil),
 			)
 		}
 
-		r.chainIDIndex[chainID] = chain
+		r.chainIDIndex[chain.ChainID] = chain
 
 		lmt.Logger(context.Background()).Debug(
 			"indexed chain configuration",
-			zap.String("chainID", chainID),
+			zap.String("chainID", chain.ChainID),
 			zap.Any("chainConfig", chain))
 	}
 }


### PR DESCRIPTION
This fixes two bugs
1. When settling a batch of orders, the order settler would try to insert a tx into the submitted txs table for each settlement in the batch. However all settlements are settled in a single tx so this was violating the unique constraint on the db and causing an error.
2. The config reader was creating the map keyed by the chain name instead of chain id, this fixes that