### PR TITLE
[API-3556] ensure signatures in hyperlane process call are in correct order

### DIFF
--- a/hyperlane/client.go
+++ b/hyperlane/client.go
@@ -17,7 +17,7 @@ type Client interface {
 	HasBeenDelivered(ctx context.Context, destinationDomain string, messageID string) (bool, error)
 	ISMType(ctx context.Context, domain string, recipient string) (uint8, error)
 	ValidatorsAndThreshold(ctx context.Context, domain string, recipient string, message string) ([]common.Address, uint8, error)
-	ValidatorStorageLocations(ctx context.Context, domain string, validators []common.Address) (*types.ValidatorStorageLocations, error)
+	ValidatorStorageLocations(ctx context.Context, domain string, validators []common.Address) ([]types.ValidatorStorageLocation, error)
 	MerkleTreeLeafCount(ctx context.Context, domain string) (uint64, error)
 	Process(ctx context.Context, domain string, message []byte, metadata []byte) ([]byte, error)
 	IsContract(ctx context.Context, domain, address string) (bool, error)
@@ -97,7 +97,7 @@ func (c *MultiClient) ValidatorStorageLocations(
 	ctx context.Context,
 	domain string,
 	validators []common.Address,
-) (*types.ValidatorStorageLocations, error) {
+) ([]types.ValidatorStorageLocation, error) {
 	client, ok := c.clients[domain]
 	if !ok {
 		return nil, fmt.Errorf("no configured client for domain %s", domain)

--- a/hyperlane/cosmos/client.go
+++ b/hyperlane/cosmos/client.go
@@ -202,7 +202,7 @@ func (c *HyperlaneClient) ValidatorStorageLocations(
 	ctx context.Context,
 	domain string,
 	validators []common.Address,
-) (*types.ValidatorStorageLocations, error) {
+) ([]types.ValidatorStorageLocation, error) {
 	if domain != c.hyperlaneDomain {
 		return nil, fmt.Errorf("expected domain %s but got %s", c.hyperlaneDomain, domain)
 	}

--- a/hyperlane/cosmos/validator_announce.go
+++ b/hyperlane/cosmos/validator_announce.go
@@ -27,7 +27,7 @@ type GetAnnounceStorageLoctions struct {
 	Validators []string `json:"validators"`
 }
 
-func (va *ValidatorAnnounceQuerier) GetAnnouncedValidatorStorageLocations(ctx context.Context, validators []string) (*types.ValidatorStorageLocations, error) {
+func (va *ValidatorAnnounceQuerier) GetAnnouncedValidatorStorageLocations(ctx context.Context, validators []string) ([]types.ValidatorStorageLocation, error) {
 	var stripped []string
 	for _, v := range validators {
 		stripped = append(stripped, strings.TrimPrefix(v, "0x"))
@@ -60,7 +60,7 @@ func (va *ValidatorAnnounceQuerier) GetAnnouncedValidatorStorageLocations(ctx co
 		return nil, fmt.Errorf("unmarshaling repsonse bytes into storage locations json: %w", err)
 	}
 
-	validatorStorageLocations := types.ValidatorStorageLocations{StorageLocations: make(map[string]string)}
+	var validatorStorageLocations []types.ValidatorStorageLocation
 	for _, validatorLocation := range validatorLocations.StorageLocations {
 		// each entry in the array is a two item slice, the first is the
 		// validator address as a string, the second is an array of storage
@@ -86,8 +86,8 @@ func (va *ValidatorAnnounceQuerier) GetAnnouncedValidatorStorageLocations(ctx co
 			return nil, fmt.Errorf("got unexpected type for second element of validator storge location, exepcted string")
 		}
 
-		validatorStorageLocations.StorageLocations[validator] = location
+		validatorStorageLocations = append(validatorStorageLocations, types.ValidatorStorageLocation{Validator: validator, StorageLocation: location})
 	}
 
-	return &validatorStorageLocations, nil
+	return validatorStorageLocations, nil
 }

--- a/hyperlane/ethereum/client.go
+++ b/hyperlane/ethereum/client.go
@@ -241,7 +241,7 @@ func (c *HyperlaneClient) ValidatorStorageLocations(
 	ctx context.Context,
 	domain string,
 	validators []common.Address,
-) (*types.ValidatorStorageLocations, error) {
+) ([]types.ValidatorStorageLocation, error) {
 	panic("not implemented")
 }
 

--- a/hyperlane/relayer.go
+++ b/hyperlane/relayer.go
@@ -88,19 +88,19 @@ func (r *relayer) Relay(ctx context.Context, originChainID string, initiateTxHas
 
 	lmt.Logger(ctx).Debug(
 		"got validator storage locations",
-		zap.Any("validatorStorageLocations", validatorStorageLocations.StorageLocations),
+		zap.Any("validatorStorageLocations", validatorStorageLocations),
 	)
 
 	// create fetchers for the validators storage locations (either S3 or local
 	// files)
 	var checkpointFetchers []CheckpointFetcher
-	for validator, storageLocation := range validatorStorageLocations.StorageLocations {
-		if override, ok := r.storageLocationOverrides[validator]; ok {
-			storageLocation = override
+	for _, validatorStorageLocation := range validatorStorageLocations {
+		if override, ok := r.storageLocationOverrides[validatorStorageLocation.Validator]; ok {
+			validatorStorageLocation.StorageLocation = override
 		}
-		fetcher, err := NewCheckpointFetcherFromStorageLocation(storageLocation, validator)
+		fetcher, err := NewCheckpointFetcherFromStorageLocation(validatorStorageLocation.StorageLocation, validatorStorageLocation.Validator)
 		if err != nil {
-			return "", "", fmt.Errorf("creating checkpoint fetcher from storage location %s for validator %s: %w", storageLocation, validator, err)
+			return "", "", fmt.Errorf("creating checkpoint fetcher from storage location %s for validator %s: %w", validatorStorageLocation.StorageLocation, validatorStorageLocation.Validator, err)
 		}
 		checkpointFetchers = append(checkpointFetchers, fetcher)
 	}

--- a/hyperlane/types/types.go
+++ b/hyperlane/types/types.go
@@ -11,9 +11,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
-type ValidatorStorageLocations struct {
-	// StorageLocations is a map of validator addresses to storage locations
-	StorageLocations map[string]string
+type ValidatorStorageLocation struct {
+	Validator       string
+	StorageLocation string
 }
 
 type SignedCheckpoint struct {


### PR DESCRIPTION
The hyperlane multisig ism expects signatures to be in a certain order https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/836060240bc4d2ea0871e633b5802419cadcc95b/solidity/contracts/isms/multisig/AbstractMultisigIsm.sol#L93. This PR replaces a non-deterministic map iteration that was causing the relayer to submit signatures in the incorrect order with logic that adheres to the order expected by the ism.