### PR TITLE
[API-3558] Deterministic hyperlane validator signature ordering

### DIFF
--- a/hyperlane/client.go
+++ b/hyperlane/client.go
@@ -17,7 +17,7 @@ type Client interface {
 	HasBeenDelivered(ctx context.Context, destinationDomain string, messageID string) (bool, error)
 	ISMType(ctx context.Context, domain string, recipient string) (uint8, error)
 	ValidatorsAndThreshold(ctx context.Context, domain string, recipient string, message string) ([]common.Address, uint8, error)
-	ValidatorStorageLocations(ctx context.Context, domain string, validators []common.Address) (*types.ValidatorStorageLocations, error)
+	ValidatorStorageLocations(ctx context.Context, domain string, validators []common.Address) ([]*types.ValidatorStorageLocation, error)
 	MerkleTreeLeafCount(ctx context.Context, domain string) (uint64, error)
 	Process(ctx context.Context, domain string, message []byte, metadata []byte) ([]byte, error)
 	IsContract(ctx context.Context, domain, address string) (bool, error)
@@ -97,7 +97,7 @@ func (c *MultiClient) ValidatorStorageLocations(
 	ctx context.Context,
 	domain string,
 	validators []common.Address,
-) (*types.ValidatorStorageLocations, error) {
+) ([]*types.ValidatorStorageLocation, error) {
 	client, ok := c.clients[domain]
 	if !ok {
 		return nil, fmt.Errorf("no configured client for domain %s", domain)

--- a/hyperlane/cosmos/client.go
+++ b/hyperlane/cosmos/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+
 	"google.golang.org/grpc/credentials"
 
 	"strconv"
@@ -202,7 +203,7 @@ func (c *HyperlaneClient) ValidatorStorageLocations(
 	ctx context.Context,
 	domain string,
 	validators []common.Address,
-) (*types.ValidatorStorageLocations, error) {
+) ([]*types.ValidatorStorageLocation, error) {
 	if domain != c.hyperlaneDomain {
 		return nil, fmt.Errorf("expected domain %s but got %s", c.hyperlaneDomain, domain)
 	}

--- a/hyperlane/ethereum/client.go
+++ b/hyperlane/ethereum/client.go
@@ -241,7 +241,7 @@ func (c *HyperlaneClient) ValidatorStorageLocations(
 	ctx context.Context,
 	domain string,
 	validators []common.Address,
-) (*types.ValidatorStorageLocations, error) {
+) ([]*types.ValidatorStorageLocation, error) {
 	panic("not implemented")
 }
 

--- a/hyperlane/relayer.go
+++ b/hyperlane/relayer.go
@@ -88,16 +88,19 @@ func (r *relayer) Relay(ctx context.Context, originChainID string, initiateTxHas
 
 	lmt.Logger(ctx).Debug(
 		"got validator storage locations",
-		zap.Any("validatorStorageLocations", validatorStorageLocations.StorageLocations),
+		zap.Any("validatorStorageLocations", validatorStorageLocations),
 	)
 
 	// create fetchers for the validators storage locations (either S3 or local
 	// files)
 	var checkpointFetchers []CheckpointFetcher
-	for validator, storageLocation := range validatorStorageLocations.StorageLocations {
+	for _, validatorStorageLocation := range validatorStorageLocations {
+		validator := validatorStorageLocation.Validator
+		storageLocation := validatorStorageLocation.StorageLocation
 		if override, ok := r.storageLocationOverrides[validator]; ok {
 			storageLocation = override
 		}
+
 		fetcher, err := NewCheckpointFetcherFromStorageLocation(storageLocation, validator)
 		if err != nil {
 			return "", "", fmt.Errorf("creating checkpoint fetcher from storage location %s for validator %s: %w", storageLocation, validator, err)

--- a/hyperlane/types/types.go
+++ b/hyperlane/types/types.go
@@ -11,9 +11,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
-type ValidatorStorageLocations struct {
-	// StorageLocations is a map of validator addresses to storage locations
-	StorageLocations map[string]string
+type ValidatorStorageLocation struct {
+	Validator       string
+	StorageLocation string
 }
 
 type SignedCheckpoint struct {


### PR DESCRIPTION
add validator signatures to message metadata in the same order that they were retrieved from the validator announce contract