### PR TITLE
[API-3547] OrderSettler findNewSettlements infura rpc optimization

### DIFF
--- a/db/gen/db/order_settlements.sql.go
+++ b/db/gen/db/order_settlements.sql.go
@@ -50,6 +50,36 @@ func (q *Queries) GetAllOrderSettlementsWithSettlementStatus(ctx context.Context
 	return items, nil
 }
 
+const getOrderSettlement = `-- name: GetOrderSettlement :one
+SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE source_chain_id = ? AND source_chain_gateway_contract_address = ? AND order_id = ?
+`
+
+type GetOrderSettlementParams struct {
+	SourceChainID                     string
+	SourceChainGatewayContractAddress string
+	OrderID                           string
+}
+
+func (q *Queries) GetOrderSettlement(ctx context.Context, arg GetOrderSettlementParams) (OrderSettlement, error) {
+	row := q.db.QueryRowContext(ctx, getOrderSettlement, arg.SourceChainID, arg.SourceChainGatewayContractAddress, arg.OrderID)
+	var i OrderSettlement
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.SourceChainID,
+		&i.DestinationChainID,
+		&i.SourceChainGatewayContractAddress,
+		&i.Amount,
+		&i.OrderID,
+		&i.InitiateSettlementTx,
+		&i.CompleteSettlementTx,
+		&i.SettlementStatus,
+		&i.SettlementStatusMessage,
+	)
+	return i, err
+}
+
 const insertOrderSettlement = `-- name: InsertOrderSettlement :one
 INSERT INTO order_settlements (
     source_chain_id,

--- a/db/gen/db/querier.go
+++ b/db/gen/db/querier.go
@@ -14,6 +14,7 @@ type Querier interface {
 	GetAllOrderSettlementsWithSettlementStatus(ctx context.Context, settlementStatus string) ([]OrderSettlement, error)
 	GetAllOrdersWithOrderStatus(ctx context.Context, orderStatus string) ([]Order, error)
 	GetAllPendingRebalanceTransfers(ctx context.Context) ([]GetAllPendingRebalanceTransfersRow, error)
+	GetOrderSettlement(ctx context.Context, arg GetOrderSettlementParams) (OrderSettlement, error)
 	GetPendingRebalanceTransfersToChain(ctx context.Context, destinationChainID string) ([]GetPendingRebalanceTransfersToChainRow, error)
 	GetSubmittedTxsByHyperlaneTransferId(ctx context.Context, hyperlaneTransferID sql.NullInt64) ([]SubmittedTx, error)
 	GetSubmittedTxsByOrderIdAndType(ctx context.Context, arg GetSubmittedTxsByOrderIdAndTypeParams) ([]SubmittedTx, error)

--- a/db/queries/order_settlements.sql
+++ b/db/queries/order_settlements.sql
@@ -11,6 +11,9 @@ INSERT INTO order_settlements (
 -- name: GetAllOrderSettlementsWithSettlementStatus :many
 SELECT * FROM order_settlements WHERE settlement_status = ?;
 
+-- name: GetOrderSettlement :one
+SELECT * FROM order_settlements WHERE source_chain_id = ? AND source_chain_gateway_contract_address = ? AND order_id = ?;
+
 -- name: SetInitiateSettlementTx :one
 UPDATE order_settlements
 SET updated_at=CURRENT_TIMESTAMP, initiate_settlement_tx = ?

--- a/shared/bridges/cctp/cosmos_bridge_client.go
+++ b/shared/bridges/cctp/cosmos_bridge_client.go
@@ -472,6 +472,7 @@ func (c *CosmosBridgeClient) OrderFillsByFiller(ctx context.Context, gatewayCont
 	var startAfter *string
 	const limit uint64 = 100
 
+	var fills []Fill
 	for {
 		query := struct {
 			OrderFillsByFiller struct {
@@ -503,19 +504,22 @@ func (c *CosmosBridgeClient) OrderFillsByFiller(ctx context.Context, gatewayCont
 			return nil, fmt.Errorf("failed to query smart contract state: %w", err)
 		}
 
-		var fills []Fill
-		if err := json.Unmarshal(resp.Data, &fills); err != nil {
+		var page []Fill
+		if err := json.Unmarshal(resp.Data, &page); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 		}
 
+		fills = append(fills, page...)
+
 		// If we received fewer results than the limit, we've reached the end
-		if len(fills) < int(limit) {
-			return fills, nil
+		if len(page) < int(limit) {
+			break
 		}
 
 		// Set the startAfter for the next iteration
-		startAfter = &fills[len(fills)-1].OrderID
+		startAfter = &page[len(page)-1].OrderID
 	}
+	return fills, nil
 }
 
 func (c *CosmosBridgeClient) WaitForTx(ctx context.Context, txHash string) error {


### PR DESCRIPTION
The OrderSettler findNewSettlements function queries all order fills by the solver from the destination contract and then performs some queries on the source gateway for additional details about the order. This PR adds a check that skips the source gateway queries if the order settlement has already been ingested.