### PR TITLE
document key storage options in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ make build-cli # build cli tool
 - [Hyperlane Docs Link](https://docs.hyperlane.xyz/)
 
 ### Key Management
+
 Besides storing keys in a plaintext config file, users can also:
+
 - Run the solver with the flag `--key-store-type env` and store a json string of the keys map in the environment variable `SOLVER_KEYS`.
-The keys map json string should be formed like [this](config/local/keys.json).
+  The keys map json string should be formed like [this](config/local/keys.json).
 - Store keys in an encrypted file and run the solver with the flags `--key-store-type encrypted-file --keys <path to encrypted keys file> --aes-key-hex <hex encoded aes key for decryption>`.
-An example of how the encrypted file should be formed can be found [here](examples/encrypted_key_store/main.go).
+  An example of how the encrypted file should be formed can be found [here](examples/encrypted_key_store/main.go).

--- a/README.md
+++ b/README.md
@@ -124,3 +124,10 @@ make build-cli # build cli tool
 ### Hyperlane Docs
 
 - [Hyperlane Docs Link](https://docs.hyperlane.xyz/)
+
+### Key Management
+Besides storing keys in a plaintext config file, users can also:
+- Run the solver with the flag `--key-store-type env` and store a json string of the keys map in the environment variable `SOLVER_KEYS`.
+The keys map json string should be formed like [this](config/local/keys.json).
+- Store keys in an encrypted file and run the solver with the flags `--key-store-type encrypted-file --keys <path to encrypted keys file> --aes-key-hex <hex encoded aes key for decryption>`.
+An example of how the encrypted file should be formed can be found [here](examples/encrypted_key_store/main.go).

--- a/examples/encrypted_key_store/main.go
+++ b/examples/encrypted_key_store/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"github.com/skip-mev/go-fast-solver/shared/keys"
+	"os"
+)
+
+func main() {
+	solverKeys := map[string]map[string]string{
+		"chain1": {"private_key": "key1"},
+		"chain2": {"private_key": "key2"},
+	}
+	jsonData, _ := json.Marshal(solverKeys)
+
+	// Create a test AES key
+	aesKey := []byte("0123456789abcdef0123456789abcdef")
+	aesKeyHex := hex.EncodeToString(aesKey)
+
+	// Encrypt the test data
+	encryptedData := encryptSolverKeys(jsonData, aesKey)
+	encryptedDataHex := hex.EncodeToString(encryptedData)
+
+	// Create a temporary file with encrypted data
+	testFile := createTempFileWithContent([]byte(encryptedDataHex))
+	defer os.Remove(testFile.Name())
+
+	// Load keys from encrypted file
+	result, _ := keys.LoadKeyStoreFromEncryptedFile(testFile.Name(), aesKeyHex)
+	resultJson, _ := json.Marshal(result)
+
+	// This is just an example, of course don't log your real private keys
+	fmt.Printf("Decrypted keys %s", string(resultJson))
+}
+
+func createTempFileWithContent(content []byte) *os.File {
+	file, _ := os.CreateTemp("", "keystore_test")
+
+	_, _ = file.Write(content)
+
+	_ = file.Close()
+
+	return file
+}
+
+func encryptSolverKeys(data []byte, key []byte) []byte {
+	block, _ := aes.NewCipher(key)
+
+	gcm, _ := cipher.NewGCM(block)
+
+	nonce := make([]byte, gcm.NonceSize())
+	ciphertext := gcm.Seal(nil, nonce, data, nil)
+	return append(nonce, ciphertext...)
+}


### PR DESCRIPTION
- document key storage options in readme
- add an example for how the encrypted file should be formed