### PR TITLE
[API-3580] track order settlement fee amounts in db

### DIFF
--- a/db/gen/db/models.go
+++ b/db/gen/db/models.go
@@ -54,7 +54,7 @@ type OrderSettlement struct {
 	DestinationChainID                string
 	SourceChainGatewayContractAddress string
 	Amount                            string
-	Fee                               string
+	Profit                            string
 	OrderID                           string
 	InitiateSettlementTx              sql.NullString
 	CompleteSettlementTx              sql.NullString

--- a/db/gen/db/models.go
+++ b/db/gen/db/models.go
@@ -54,6 +54,7 @@ type OrderSettlement struct {
 	DestinationChainID                string
 	SourceChainGatewayContractAddress string
 	Amount                            string
+	Fee                               string
 	OrderID                           string
 	InitiateSettlementTx              sql.NullString
 	CompleteSettlementTx              sql.NullString

--- a/db/gen/db/order_settlements.sql.go
+++ b/db/gen/db/order_settlements.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const getAllOrderSettlementsWithSettlementStatus = `-- name: GetAllOrderSettlementsWithSettlementStatus :many
-SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE settlement_status = ?
+SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, profit, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE settlement_status = ?
 `
 
 func (q *Queries) GetAllOrderSettlementsWithSettlementStatus(ctx context.Context, settlementStatus string) ([]OrderSettlement, error) {
@@ -31,7 +31,7 @@ func (q *Queries) GetAllOrderSettlementsWithSettlementStatus(ctx context.Context
 			&i.DestinationChainID,
 			&i.SourceChainGatewayContractAddress,
 			&i.Amount,
-			&i.Fee,
+			&i.Profit,
 			&i.OrderID,
 			&i.InitiateSettlementTx,
 			&i.CompleteSettlementTx,
@@ -52,7 +52,7 @@ func (q *Queries) GetAllOrderSettlementsWithSettlementStatus(ctx context.Context
 }
 
 const getOrderSettlement = `-- name: GetOrderSettlement :one
-SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE source_chain_id = ? AND source_chain_gateway_contract_address = ? AND order_id = ?
+SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, profit, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE source_chain_id = ? AND source_chain_gateway_contract_address = ? AND order_id = ?
 `
 
 type GetOrderSettlementParams struct {
@@ -72,7 +72,7 @@ func (q *Queries) GetOrderSettlement(ctx context.Context, arg GetOrderSettlement
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
-		&i.Fee,
+		&i.Profit,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -88,10 +88,10 @@ INSERT INTO order_settlements (
     destination_chain_id,
     source_chain_gateway_contract_address,
     amount,
-    fee,
+    profit,
     order_id,
     settlement_status
-) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, profit, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type InsertOrderSettlementParams struct {
@@ -99,7 +99,7 @@ type InsertOrderSettlementParams struct {
 	DestinationChainID                string
 	SourceChainGatewayContractAddress string
 	Amount                            string
-	Fee                               string
+	Profit                            string
 	OrderID                           string
 	SettlementStatus                  string
 }
@@ -110,7 +110,7 @@ func (q *Queries) InsertOrderSettlement(ctx context.Context, arg InsertOrderSett
 		arg.DestinationChainID,
 		arg.SourceChainGatewayContractAddress,
 		arg.Amount,
-		arg.Fee,
+		arg.Profit,
 		arg.OrderID,
 		arg.SettlementStatus,
 	)
@@ -123,7 +123,7 @@ func (q *Queries) InsertOrderSettlement(ctx context.Context, arg InsertOrderSett
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
-		&i.Fee,
+		&i.Profit,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -137,7 +137,7 @@ const setCompleteSettlementTx = `-- name: SetCompleteSettlementTx :one
 UPDATE order_settlements
 SET updated_at=CURRENT_TIMESTAMP, complete_settlement_tx = ?
 WHERE source_chain_id = ? AND order_id = ? AND source_chain_gateway_contract_address = ?
-    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, profit, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type SetCompleteSettlementTxParams struct {
@@ -163,7 +163,7 @@ func (q *Queries) SetCompleteSettlementTx(ctx context.Context, arg SetCompleteSe
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
-		&i.Fee,
+		&i.Profit,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -177,7 +177,7 @@ const setInitiateSettlementTx = `-- name: SetInitiateSettlementTx :one
 UPDATE order_settlements
 SET updated_at=CURRENT_TIMESTAMP, initiate_settlement_tx = ?
 WHERE source_chain_id = ? AND order_id = ? AND source_chain_gateway_contract_address = ?
-    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, profit, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type SetInitiateSettlementTxParams struct {
@@ -203,7 +203,7 @@ func (q *Queries) SetInitiateSettlementTx(ctx context.Context, arg SetInitiateSe
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
-		&i.Fee,
+		&i.Profit,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -217,7 +217,7 @@ const setSettlementStatus = `-- name: SetSettlementStatus :one
 UPDATE order_settlements
 SET updated_at=CURRENT_TIMESTAMP, settlement_status = ?, settlement_status_message = ?
 WHERE source_chain_id = ? AND order_id = ? AND source_chain_gateway_contract_address = ?
-    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, profit, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type SetSettlementStatusParams struct {
@@ -245,7 +245,7 @@ func (q *Queries) SetSettlementStatus(ctx context.Context, arg SetSettlementStat
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
-		&i.Fee,
+		&i.Profit,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,

--- a/db/gen/db/order_settlements.sql.go
+++ b/db/gen/db/order_settlements.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const getAllOrderSettlementsWithSettlementStatus = `-- name: GetAllOrderSettlementsWithSettlementStatus :many
-SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE settlement_status = ?
+SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE settlement_status = ?
 `
 
 func (q *Queries) GetAllOrderSettlementsWithSettlementStatus(ctx context.Context, settlementStatus string) ([]OrderSettlement, error) {
@@ -31,6 +31,7 @@ func (q *Queries) GetAllOrderSettlementsWithSettlementStatus(ctx context.Context
 			&i.DestinationChainID,
 			&i.SourceChainGatewayContractAddress,
 			&i.Amount,
+			&i.Fee,
 			&i.OrderID,
 			&i.InitiateSettlementTx,
 			&i.CompleteSettlementTx,
@@ -51,7 +52,7 @@ func (q *Queries) GetAllOrderSettlementsWithSettlementStatus(ctx context.Context
 }
 
 const getOrderSettlement = `-- name: GetOrderSettlement :one
-SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE source_chain_id = ? AND source_chain_gateway_contract_address = ? AND order_id = ?
+SELECT id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message FROM order_settlements WHERE source_chain_id = ? AND source_chain_gateway_contract_address = ? AND order_id = ?
 `
 
 type GetOrderSettlementParams struct {
@@ -71,6 +72,7 @@ func (q *Queries) GetOrderSettlement(ctx context.Context, arg GetOrderSettlement
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
+		&i.Fee,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -86,9 +88,10 @@ INSERT INTO order_settlements (
     destination_chain_id,
     source_chain_gateway_contract_address,
     amount,
+    fee,
     order_id,
     settlement_status
-) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type InsertOrderSettlementParams struct {
@@ -96,6 +99,7 @@ type InsertOrderSettlementParams struct {
 	DestinationChainID                string
 	SourceChainGatewayContractAddress string
 	Amount                            string
+	Fee                               string
 	OrderID                           string
 	SettlementStatus                  string
 }
@@ -106,6 +110,7 @@ func (q *Queries) InsertOrderSettlement(ctx context.Context, arg InsertOrderSett
 		arg.DestinationChainID,
 		arg.SourceChainGatewayContractAddress,
 		arg.Amount,
+		arg.Fee,
 		arg.OrderID,
 		arg.SettlementStatus,
 	)
@@ -118,6 +123,7 @@ func (q *Queries) InsertOrderSettlement(ctx context.Context, arg InsertOrderSett
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
+		&i.Fee,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -131,7 +137,7 @@ const setCompleteSettlementTx = `-- name: SetCompleteSettlementTx :one
 UPDATE order_settlements
 SET updated_at=CURRENT_TIMESTAMP, complete_settlement_tx = ?
 WHERE source_chain_id = ? AND order_id = ? AND source_chain_gateway_contract_address = ?
-    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type SetCompleteSettlementTxParams struct {
@@ -157,6 +163,7 @@ func (q *Queries) SetCompleteSettlementTx(ctx context.Context, arg SetCompleteSe
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
+		&i.Fee,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -170,7 +177,7 @@ const setInitiateSettlementTx = `-- name: SetInitiateSettlementTx :one
 UPDATE order_settlements
 SET updated_at=CURRENT_TIMESTAMP, initiate_settlement_tx = ?
 WHERE source_chain_id = ? AND order_id = ? AND source_chain_gateway_contract_address = ?
-    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type SetInitiateSettlementTxParams struct {
@@ -196,6 +203,7 @@ func (q *Queries) SetInitiateSettlementTx(ctx context.Context, arg SetInitiateSe
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
+		&i.Fee,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,
@@ -209,7 +217,7 @@ const setSettlementStatus = `-- name: SetSettlementStatus :one
 UPDATE order_settlements
 SET updated_at=CURRENT_TIMESTAMP, settlement_status = ?, settlement_status_message = ?
 WHERE source_chain_id = ? AND order_id = ? AND source_chain_gateway_contract_address = ?
-    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
+    RETURNING id, created_at, updated_at, source_chain_id, destination_chain_id, source_chain_gateway_contract_address, amount, fee, order_id, initiate_settlement_tx, complete_settlement_tx, settlement_status, settlement_status_message
 `
 
 type SetSettlementStatusParams struct {
@@ -237,6 +245,7 @@ func (q *Queries) SetSettlementStatus(ctx context.Context, arg SetSettlementStat
 		&i.DestinationChainID,
 		&i.SourceChainGatewayContractAddress,
 		&i.Amount,
+		&i.Fee,
 		&i.OrderID,
 		&i.InitiateSettlementTx,
 		&i.CompleteSettlementTx,

--- a/db/migrations/000003_add_order_settlements_table.up.sql
+++ b/db/migrations/000003_add_order_settlements_table.up.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS order_settlements (
     destination_chain_id TEXT NOT NULL,
     source_chain_gateway_contract_address TEXT NOT NULL,
     amount TEXT NOT NULL,
+    fee TEXT NOT NULL,
     order_id TEXT NOT NULL,
 
     initiate_settlement_tx TEXT,

--- a/db/migrations/000003_add_order_settlements_table.up.sql
+++ b/db/migrations/000003_add_order_settlements_table.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS order_settlements (
     destination_chain_id TEXT NOT NULL,
     source_chain_gateway_contract_address TEXT NOT NULL,
     amount TEXT NOT NULL,
-    fee TEXT NOT NULL,
+    profit TEXT NOT NULL,
     order_id TEXT NOT NULL,
 
     initiate_settlement_tx TEXT,

--- a/db/queries/order_settlements.sql
+++ b/db/queries/order_settlements.sql
@@ -4,9 +4,10 @@ INSERT INTO order_settlements (
     destination_chain_id,
     source_chain_gateway_contract_address,
     amount,
+    fee,
     order_id,
     settlement_status
-) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING RETURNING *;
+) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING RETURNING *;
 
 -- name: GetAllOrderSettlementsWithSettlementStatus :many
 SELECT * FROM order_settlements WHERE settlement_status = ?;

--- a/db/queries/order_settlements.sql
+++ b/db/queries/order_settlements.sql
@@ -4,7 +4,7 @@ INSERT INTO order_settlements (
     destination_chain_id,
     source_chain_gateway_contract_address,
     amount,
-    fee,
+    profit,
     order_id,
     settlement_status
 ) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING RETURNING *;

--- a/ordersettler/ordersettler.go
+++ b/ordersettler/ordersettler.go
@@ -183,7 +183,7 @@ func (r *OrderSettler) findNewSettlements(ctx context.Context) error {
 			} else if orderDetails == nil {
 				return fmt.Errorf("could not find order submitted event on chain %s for order %s", sourceChainID, fill.OrderID)
 			}
-			fee := big.NewInt(0).Sub(orderDetails.AmountIn, orderDetails.AmountOut)
+			profit := big.NewInt(0).Sub(orderDetails.AmountIn, orderDetails.AmountOut)
 
 			_, err = r.db.InsertOrderSettlement(ctx, db.InsertOrderSettlementParams{
 				SourceChainID:                     sourceChainID,
@@ -192,7 +192,7 @@ func (r *OrderSettler) findNewSettlements(ctx context.Context) error {
 				OrderID:                           fill.OrderID,
 				SettlementStatus:                  dbtypes.SettlementStatusPending,
 				Amount:                            amount.String(),
-				Fee:                               fee.String(),
+				Profit:                            profit.String(),
 			})
 
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -342,7 +342,7 @@ func (r *OrderSettler) relaySettlement(
 }
 
 func (r *OrderSettler) maxBatchTxFeeUUSDC(ctx context.Context, batch types.SettlementBatch) (*big.Int, error) {
-	profit, err := batch.TotalFee()
+	profit, err := batch.TotalProfit()
 	if err != nil {
 		return nil, fmt.Errorf("calculating profit for batch: %w", err)
 	}

--- a/ordersettler/ordersettler.go
+++ b/ordersettler/ordersettler.go
@@ -37,8 +37,6 @@ var params = Config{
 type Database interface {
 	GetAllOrderSettlementsWithSettlementStatus(ctx context.Context, settlementStatus string) ([]db.OrderSettlement, error)
 
-	GetOrderByOrderID(ctx context.Context, orderID string) (db.Order, error)
-
 	SetSettlementStatus(ctx context.Context, arg db.SetSettlementStatusParams) (db.OrderSettlement, error)
 
 	SetInitiateSettlementTx(ctx context.Context, arg db.SetInitiateSettlementTxParams) (db.OrderSettlement, error)
@@ -179,6 +177,14 @@ func (r *OrderSettler) findNewSettlements(ctx context.Context) error {
 				continue
 			}
 
+			orderDetails, err := sourceBridgeClient.QueryOrderSubmittedEvent(ctx, sourceGatewayAddress, fill.OrderID)
+			if err != nil {
+				return fmt.Errorf("getting order submitted event on chain %s for order %s: %w", sourceChainID, fill.OrderID, err)
+			} else if orderDetails == nil {
+				return fmt.Errorf("could not find order submitted event on chain %s for order %s", sourceChainID, fill.OrderID)
+			}
+			fee := big.NewInt(0).Sub(orderDetails.AmountIn, orderDetails.AmountOut)
+
 			_, err = r.db.InsertOrderSettlement(ctx, db.InsertOrderSettlementParams{
 				SourceChainID:                     sourceChainID,
 				DestinationChainID:                chain.ChainID,
@@ -186,6 +192,7 @@ func (r *OrderSettler) findNewSettlements(ctx context.Context) error {
 				OrderID:                           fill.OrderID,
 				SettlementStatus:                  dbtypes.SettlementStatusPending,
 				Amount:                            amount.String(),
+				Fee:                               fee.String(),
 			})
 
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -335,7 +342,7 @@ func (r *OrderSettler) relaySettlement(
 }
 
 func (r *OrderSettler) maxBatchTxFeeUUSDC(ctx context.Context, batch types.SettlementBatch) (*big.Int, error) {
-	profit, err := r.totalBatchProfit(ctx, batch)
+	profit, err := batch.TotalFee()
 	if err != nil {
 		return nil, fmt.Errorf("calculating profit for batch: %w", err)
 	}
@@ -356,32 +363,6 @@ func (r *OrderSettler) maxBatchTxFeeUUSDC(ctx context.Context, batch types.Settl
 	valueMarginInt, _ := valueMargin.Int(nil)
 
 	return profit.Sub(profit, valueMarginInt), nil
-}
-
-func (r *OrderSettler) totalBatchProfit(ctx context.Context, batch types.SettlementBatch) (*big.Int, error) {
-	totalAmountIn, err := batch.TotalValue()
-	if err != nil {
-		return nil, fmt.Errorf("getting batches total value: %w", err)
-	}
-
-	totalAmountOut := big.NewInt(0)
-	for _, settlement := range batch {
-		// settlements dont store the amount out of the order, in order to
-		// calculate the profit, we have to look that up from the db
-		order, err := r.db.GetOrderByOrderID(ctx, settlement.OrderID)
-		if err != nil {
-			return nil, fmt.Errorf("getting order %s for settlement: %w", settlement.OrderID, err)
-		}
-
-		amountOut, ok := new(big.Int).SetString(order.AmountOut, 10)
-		if !ok {
-			return nil, fmt.Errorf("converting order %s's amount out %s to *big.Int", order.OrderID, order.AmountOut)
-		}
-
-		totalAmountOut.Add(totalAmountOut, amountOut)
-	}
-
-	return totalAmountIn.Sub(totalAmountIn, totalAmountOut), nil
 }
 
 // verifyOrderSettlements checks on all instated settlements and updates their

--- a/ordersettler/types/settlements.go
+++ b/ordersettler/types/settlements.go
@@ -136,6 +136,18 @@ func (b SettlementBatch) TotalValue() (*big.Int, error) {
 	return sum, nil
 }
 
+func (b SettlementBatch) TotalFee() (*big.Int, error) {
+	sum := big.NewInt(0)
+	for _, settlement := range b {
+		value, ok := new(big.Int).SetString(settlement.Fee, 10)
+		if !ok {
+			return nil, fmt.Errorf("converting settlement fee %s to *big.Int", settlement.Fee)
+		}
+		sum = sum.Add(sum, value)
+	}
+	return sum, nil
+}
+
 func (b SettlementBatch) String() string {
 	return fmt.Sprintf(
 		"SourceChainID: %s, DestinationChainID: %s, NumOrdersInBatch: %d",

--- a/ordersettler/types/settlements.go
+++ b/ordersettler/types/settlements.go
@@ -136,12 +136,12 @@ func (b SettlementBatch) TotalValue() (*big.Int, error) {
 	return sum, nil
 }
 
-func (b SettlementBatch) TotalFee() (*big.Int, error) {
+func (b SettlementBatch) TotalProfit() (*big.Int, error) {
 	sum := big.NewInt(0)
 	for _, settlement := range b {
-		value, ok := new(big.Int).SetString(settlement.Fee, 10)
+		value, ok := new(big.Int).SetString(settlement.Profit, 10)
 		if !ok {
-			return nil, fmt.Errorf("converting settlement fee %s to *big.Int", settlement.Fee)
+			return nil, fmt.Errorf("converting settlement profit %s to *big.Int", settlement.Profit)
 		}
 		sum = sum.Add(sum, value)
 	}

--- a/shared/bridges/cctp/bridge_client.go
+++ b/shared/bridges/cctp/bridge_client.go
@@ -3,6 +3,7 @@ package cctp
 import (
 	"context"
 	"fmt"
+	"github.com/skip-mev/go-fast-solver/shared/contracts/fast_transfer_gateway"
 	"math/big"
 	"time"
 
@@ -62,4 +63,5 @@ type BridgeClient interface {
 	IsOrderRefunded(ctx context.Context, gatewayContractAddress, orderID string) (bool, string, error)
 	InitiateTimeout(ctx context.Context, order db.Order, gatewayContractAddress string) (string, string, *uint64, error)
 	OrderStatus(ctx context.Context, gatewayContractAddress, orderID string) (uint8, error)
+	QueryOrderSubmittedEvent(ctx context.Context, gatewayContractAddress, orderID string) (*fast_transfer_gateway.FastTransferOrder, error)
 }

--- a/shared/bridges/cctp/cosmos_bridge_client.go
+++ b/shared/bridges/cctp/cosmos_bridge_client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/skip-mev/go-fast-solver/shared/contracts/fast_transfer_gateway"
 	"github.com/skip-mev/go-fast-solver/shared/txexecutor/cosmos"
 	"math/big"
 	"strconv"
@@ -578,4 +579,8 @@ func (c *CosmosBridgeClient) BlockHeight(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 	return uint64(resp.Header.Height), nil
+}
+
+func (c *CosmosBridgeClient) QueryOrderSubmittedEvent(ctx context.Context, gatewayContractAddress, orderID string) (*fast_transfer_gateway.FastTransferOrder, error) {
+	return nil, errors.New("not implemented")
 }

--- a/shared/bridges/cctp/evm_bridge_client.go
+++ b/shared/bridges/cctp/evm_bridge_client.go
@@ -295,24 +295,10 @@ func (c *EVMBridgeClient) QueryOrderSubmittedEvent(ctx context.Context, gatewayC
 	var order *fast_transfer_gateway.FastTransferOrder
 	for iterator.Next() {
 		if iterator.Event != nil {
-			decodedOrder := decodeOrder(iterator.Event.Order)
+			decodedOrder := fast_transfer_gateway.DecodeOrder(iterator.Event.Order)
 			order = &decodedOrder
 		}
 	}
 
 	return order, nil
-}
-
-func decodeOrder(bytes []byte) fast_transfer_gateway.FastTransferOrder {
-	var order fast_transfer_gateway.FastTransferOrder
-	order.Sender = [32]byte(bytes[0:32])
-	order.Recipient = [32]byte(bytes[32:64])
-	order.AmountIn = new(big.Int).SetBytes(bytes[64:96])
-	order.AmountOut = new(big.Int).SetBytes(bytes[96:128])
-	order.Nonce = uint32(new(big.Int).SetBytes(bytes[128:132]).Uint64())
-	order.SourceDomain = uint32(new(big.Int).SetBytes(bytes[132:136]).Uint64())
-	order.DestinationDomain = uint32(new(big.Int).SetBytes(bytes[136:140]).Uint64())
-	order.TimeoutTimestamp = new(big.Int).SetBytes(bytes[140:148]).Uint64()
-	order.Data = bytes[148:]
-	return order
 }

--- a/shared/bridges/cctp/evm_bridge_client.go
+++ b/shared/bridges/cctp/evm_bridge_client.go
@@ -265,3 +265,54 @@ func (c *EVMBridgeClient) OrderStatus(ctx context.Context, gatewayContractAddres
 
 	return status, nil
 }
+
+func (c *EVMBridgeClient) QueryOrderSubmittedEvent(ctx context.Context, gatewayContractAddress, orderID string) (*fast_transfer_gateway.FastTransferOrder, error) {
+	fastTransferGateway, err := fast_transfer_gateway.NewFastTransferGateway(
+		common.HexToAddress(gatewayContractAddress),
+		c.client,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	orderIDBytes, err := hex.DecodeString(orderID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create topic for OrderRefunded event to filter logs for OrderRefunded events with this orderID
+	orderSubmittedTopic := [][32]byte{[32]byte(orderIDBytes)}
+	filterOpts := &bind.FilterOpts{
+		Context: ctx,
+	}
+
+	iterator, err := fastTransferGateway.FilterOrderSubmitted(filterOpts, orderSubmittedTopic)
+	if err != nil {
+		return nil, fmt.Errorf("filtering OrderSubmitted events: %w", err)
+	}
+
+	// Find the most recent OrderRefunded event for this orderID
+	var order *fast_transfer_gateway.FastTransferOrder
+	for iterator.Next() {
+		if iterator.Event != nil {
+			decodedOrder := decodeOrder(iterator.Event.Order)
+			order = &decodedOrder
+		}
+	}
+
+	return order, nil
+}
+
+func decodeOrder(bytes []byte) fast_transfer_gateway.FastTransferOrder {
+	var order fast_transfer_gateway.FastTransferOrder
+	order.Sender = [32]byte(bytes[0:32])
+	order.Recipient = [32]byte(bytes[32:64])
+	order.AmountIn = new(big.Int).SetBytes(bytes[64:96])
+	order.AmountOut = new(big.Int).SetBytes(bytes[96:128])
+	order.Nonce = uint32(new(big.Int).SetBytes(bytes[128:132]).Uint64())
+	order.SourceDomain = uint32(new(big.Int).SetBytes(bytes[132:136]).Uint64())
+	order.DestinationDomain = uint32(new(big.Int).SetBytes(bytes[136:140]).Uint64())
+	order.TimeoutTimestamp = new(big.Int).SetBytes(bytes[140:148]).Uint64()
+	order.Data = bytes[148:]
+	return order
+}

--- a/shared/contracts/fast_transfer_gateway/utils.go
+++ b/shared/contracts/fast_transfer_gateway/utils.go
@@ -1,0 +1,17 @@
+package fast_transfer_gateway
+
+import "math/big"
+
+func DecodeOrder(bytes []byte) FastTransferOrder {
+	var order FastTransferOrder
+	order.Sender = [32]byte(bytes[0:32])
+	order.Recipient = [32]byte(bytes[32:64])
+	order.AmountIn = new(big.Int).SetBytes(bytes[64:96])
+	order.AmountOut = new(big.Int).SetBytes(bytes[96:128])
+	order.Nonce = uint32(new(big.Int).SetBytes(bytes[128:132]).Uint64())
+	order.SourceDomain = uint32(new(big.Int).SetBytes(bytes[132:136]).Uint64())
+	order.DestinationDomain = uint32(new(big.Int).SetBytes(bytes[136:140]).Uint64())
+	order.TimeoutTimestamp = new(big.Int).SetBytes(bytes[140:148]).Uint64()
+	order.Data = bytes[148:]
+	return order
+}

--- a/transfermonitor/transfermonitor.go
+++ b/transfermonitor/transfermonitor.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"strings"
 	"sync"
 	"time"
@@ -309,7 +308,7 @@ OuterLoop:
 
 				for iter.Next() {
 					m.Lock()
-					orderData := decodeOrder(iter.Event.Order)
+					orderData := fast_transfer_gateway.DecodeOrder(iter.Event.Order)
 					orders = append(orders, Order{
 						TxHash:             iter.Event.Raw.TxHash.Hex(),
 						TxBlockHeight:      iter.Event.Raw.BlockNumber,
@@ -338,20 +337,6 @@ OuterLoop:
 		return nil, err
 	}
 	return orders, nil
-}
-
-func decodeOrder(bytes []byte) fast_transfer_gateway.FastTransferOrder {
-	var order fast_transfer_gateway.FastTransferOrder
-	order.Sender = [32]byte(bytes[0:32])
-	order.Recipient = [32]byte(bytes[32:64])
-	order.AmountIn = new(big.Int).SetBytes(bytes[64:96])
-	order.AmountOut = new(big.Int).SetBytes(bytes[96:128])
-	order.Nonce = uint32(new(big.Int).SetBytes(bytes[128:132]).Uint64())
-	order.SourceDomain = uint32(new(big.Int).SetBytes(bytes[132:136]).Uint64())
-	order.DestinationDomain = uint32(new(big.Int).SetBytes(bytes[136:140]).Uint64())
-	order.TimeoutTimestamp = new(big.Int).SetBytes(bytes[140:148]).Uint64()
-	order.Data = bytes[148:]
-	return order
 }
 
 func getChainID(chain config.ChainConfig) (string, error) {


### PR DESCRIPTION
The ordersettler right now queries the orders table for information about order amount in and amount out to determine fees. The ordersettler was intended to be able to settle all orders without assuming the existence of data in the orders table. This is important because operators will generally be running in quickstart mode and if the operator deletes the orders table for whatever reason, the order for a pending settlement may not be present in the orders table. So the order settler should be able to resolve any funds in pending settlements without data in the orders table.

This PR adds a fee column to the order settlements table and queries for order amount details via an event query. I considered creating a new migration to add the column, but for now it's easy to ask operators to delete their db.