### PR TITLE
[API-3581] gas monitor

### DIFF
--- a/cmd/solver/main.go
+++ b/cmd/solver/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/skip-mev/go-fast-solver/gasmonitor"
 	"os/signal"
 	"syscall"
 	"time"
@@ -166,6 +167,15 @@ func main() {
 		err := transferMonitor.Start(ctx)
 		if err != nil {
 			return fmt.Errorf("creating transfer monitor: %w", err)
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		gasMonitor := gasmonitor.NewGasMonitor(clientManager)
+		err := gasMonitor.Start(ctx)
+		if err != nil {
+			return fmt.Errorf("creating gas monitor: %w", err)
 		}
 		return nil
 	})

--- a/gasmonitor/gasmonitor.go
+++ b/gasmonitor/gasmonitor.go
@@ -1,0 +1,84 @@
+package gasmonitor
+
+import (
+	"context"
+	"fmt"
+	"github.com/skip-mev/go-fast-solver/shared/bridges/cctp"
+	"github.com/skip-mev/go-fast-solver/shared/clientmanager"
+	"github.com/skip-mev/go-fast-solver/shared/metrics"
+	"go.uber.org/zap"
+	"time"
+
+	"github.com/skip-mev/go-fast-solver/shared/config"
+	"github.com/skip-mev/go-fast-solver/shared/lmt"
+)
+
+type GasMonitor struct {
+	clientManager *clientmanager.ClientManager
+}
+
+func NewGasMonitor(clientManager *clientmanager.ClientManager) *GasMonitor {
+	return &GasMonitor{
+		clientManager: clientManager,
+	}
+}
+
+func (gm *GasMonitor) Start(ctx context.Context) error {
+	lmt.Logger(ctx).Info("Starting transfer monitor")
+	var chains []config.ChainConfig
+	evmChains, err := config.GetConfigReader(ctx).GetAllChainConfigsOfType(config.ChainType_EVM)
+	if err != nil {
+		return fmt.Errorf("error getting EVM chains: %w", err)
+	}
+	cosmosChains, err := config.GetConfigReader(ctx).GetAllChainConfigsOfType(config.ChainType_COSMOS)
+	if err != nil {
+		return fmt.Errorf("error getting cosmos chains: %w", err)
+	}
+	chains = append(chains, evmChains...)
+	chains = append(chains, cosmosChains...)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			for _, chain := range chains {
+				client, err := gm.clientManager.GetClient(ctx, chain.ChainID)
+				if err != nil {
+					return err
+				}
+				err = monitorGasBalance(ctx, chain.ChainID, client)
+				if err != nil {
+					lmt.Logger(ctx).Error("failed to monitor gas balance", zap.String("chain_id", chain.ChainID), zap.Error(err))
+				}
+			}
+		}
+		time.Sleep(1 * time.Minute)
+	}
+}
+
+// monitorGasBalance exports a metric indicating the current gas balance of the relayer signer and whether it is below alerting thresholds
+func monitorGasBalance(ctx context.Context, chainID string, chainClient cctp.BridgeClient) error {
+	balance, err := chainClient.SignerGasTokenBalance(ctx)
+	if err != nil {
+		lmt.Logger(ctx).Error("failed to get gas token balance", zap.Error(err), zap.String("chain_id", chainID))
+		return err
+	}
+
+	chainConfig, err := config.GetConfigReader(ctx).GetChainConfig(chainID)
+	if err != nil {
+		return err
+	}
+	warningThreshold, criticalThreshold, err := config.GetConfigReader(ctx).GetGasAlertThresholds(chainID)
+	if err != nil {
+		return err
+	}
+	if balance == nil || warningThreshold == nil || criticalThreshold == nil {
+		return fmt.Errorf("gas balance or alert thresholds are nil for chain %s", chainID)
+	}
+	if balance.Cmp(criticalThreshold) < 0 {
+		lmt.Logger(ctx).Error("low balance", zap.String("balance", balance.String()), zap.String("chainID", chainID))
+	}
+	metrics.FromContext(ctx).SetGasBalance(chainID, chainConfig.ChainName, chainConfig.GasTokenSymbol, *balance, *warningThreshold, *criticalThreshold, chainConfig.GasTokenDecimals)
+	return nil
+}

--- a/shared/bridges/cctp/cosmos_bridge_client.go
+++ b/shared/bridges/cctp/cosmos_bridge_client.go
@@ -131,7 +131,17 @@ func (c *CosmosBridgeClient) Balance(
 }
 
 func (c *CosmosBridgeClient) SignerGasTokenBalance(ctx context.Context) (*big.Int, error) {
-	return nil, errors.New("not implemented")
+	fromAddress, err := bech32.ConvertAndEncode(c.prefix, c.signer.Address())
+	if err != nil {
+		return nil, fmt.Errorf("converting signer address to bech32: %w", err)
+	}
+
+	balance, err := c.Balance(ctx, fromAddress, c.gasDenom)
+	if err != nil {
+		return nil, fmt.Errorf("querying gas token balance: %w", err)
+	}
+
+	return balance, nil
 }
 
 func (c *CosmosBridgeClient) Allowance(ctx context.Context, owner string) (*big.Int, error) {

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -353,6 +353,8 @@ type ConfigReader interface {
 	GetChainIDByHyperlaneDomain(domain string) (string, error)
 
 	GetUSDCDenom(chainID string) (string, error)
+
+	GetGasAlertThresholds(chainID string) (warningThreshold, criticalThreshold *big.Int, err error)
 }
 
 type configReader struct {
@@ -528,4 +530,34 @@ func (r configReader) GetUSDCDenom(chainID string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported chain type %s for chain %s", chainConfig.Type, chainID)
 	}
+}
+
+func (r configReader) GetGasAlertThresholds(chainID string) (warningThreshold, criticalThreshold *big.Int, err error) {
+	var warningThresholdString, criticalThresholdString string
+
+	chain, err := r.GetChainConfig(chainID)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch chain.Type {
+	case ChainType_COSMOS:
+		warningThresholdString = chain.Cosmos.SignerGasBalance.WarningThresholdWei
+		criticalThresholdString = chain.Cosmos.SignerGasBalance.CriticalThresholdWei
+	case ChainType_EVM:
+		warningThresholdString = chain.EVM.SignerGasBalance.WarningThresholdWei
+		criticalThresholdString = chain.EVM.SignerGasBalance.CriticalThresholdWei
+	default:
+		return nil, nil, fmt.Errorf("unknown chain type")
+	}
+
+	warningThreshold, ok := new(big.Int).SetString(warningThresholdString, 10)
+	if !ok {
+		return nil, nil, fmt.Errorf("failed to parse gas balance threshold amount")
+	}
+	criticalThreshold, ok = new(big.Int).SetString(criticalThresholdString, 10)
+	if !ok {
+		return nil, nil, fmt.Errorf("failed to parse gas balance threshold amount")
+	}
+
+	return warningThreshold, criticalThreshold, nil
 }


### PR DESCRIPTION
Adds a thread that periodically checks the solver's gas balances and exports the balance and whether it is considered low as a metric.