### PR TITLE
[API-3596] Relay timeout for Hyperlane transfers with max tx fees set, introduce relay cost cap for all transfers

### DIFF
--- a/cmd/solver/main.go
+++ b/cmd/solver/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	eg.Go(func() error {
 		lmt.Logger(ctx).Info("Starting Prometheus")
-		if err := metrics.StartPrometheus(ctx, fmt.Sprintf(cfg.Metrics.PrometheusAddress)); err != nil {
+		if err := metrics.StartPrometheus(ctx, cfg.Metrics.PrometheusAddress); err != nil {
 			return err
 		}
 		return nil

--- a/cmd/solvercli/cmd/submit_transfer.go
+++ b/cmd/solvercli/cmd/submit_transfer.go
@@ -145,7 +145,7 @@ func submitTransfer(cmd *cobra.Command, args []string) {
 		zap.String("source_chain_id", flags.sourceChainID),
 		zap.String("destination_chain_id", flags.destinationChainId),
 		zap.Uint32("destination_domain", uint32(destDomain)),
-		zap.Uint32("deadline_hours", flags.deadlineHours),
+		zap.Int32("deadline_hours", flags.deadlineHours),
 	)
 }
 
@@ -155,7 +155,7 @@ type submitFlags struct {
 	amountIn           string
 	amountOut          string
 	destinationChainId string
-	deadlineHours      uint32
+	deadlineHours      int32
 	gatewayAddr        string
 	configPath         string
 	sourceChainID      string
@@ -183,7 +183,7 @@ func parseFlags(cmd *cobra.Command) (*submitFlags, error) {
 	if flags.destinationChainId, err = cmd.Flags().GetString("destination-chain-id"); err != nil {
 		return nil, err
 	}
-	if flags.deadlineHours, err = cmd.Flags().GetUint32("deadline-hours"); err != nil {
+	if flags.deadlineHours, err = cmd.Flags().GetInt32("deadline-hours"); err != nil {
 		return nil, err
 	}
 	if flags.gatewayAddr, err = cmd.Flags().GetString("gateway"); err != nil {
@@ -271,7 +271,7 @@ func init() {
 	submitCmd.Flags().String("amount-out", "", "Amount out (in token decimals). Defaults to amount in if not set")
 	submitCmd.Flags().String("source-chain-id", "", "Source chain ID")
 	submitCmd.Flags().String("destination-chain-id", "", "Destination chain ID")
-	submitCmd.Flags().Uint32("deadline-hours", 24, "Deadline in hours (default of 24 hours, after which the order expires)")
+	submitCmd.Flags().Int32("deadline-hours", 24, "Deadline in hours (default of 24 hours, after which the order expires)")
 	submitCmd.Flags().String("gateway", "", "Gateway contract address")
 	submitCmd.Flags().String("private-key", "", "Private key to sign the transaction")
 

--- a/config/local/config.yml
+++ b/config/local/config.yml
@@ -54,6 +54,9 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: <warning_threshold_wei> # e.g. 4290000000000000000
         critical_threshold_wei: <critical_threshold_wei> # e.g. 1430000000000000000
+    relayer:
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc
 
   ethereum-testnet:
     chain_name: "ethereum"
@@ -80,6 +83,9 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: 250000000000000000
         critical_threshold_wei: 0
+    relayer:
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc
 
   avalanche:
     chain_name: "avalanche"
@@ -106,6 +112,9 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: <warning_threshold_wei> # e.g. 1720000000000000000
         critical_threshold_wei: <critical_threshold_wei> # e.g. 580000000000000000
+    relayer:
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc
 
   optimism:
     chain_name: "optimism"
@@ -132,6 +141,9 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: <warning_threshold_wei> # e.g. 180000000000000000
         critical_threshold_wei: <critical_threshold_wei> # e.g. 60000000000000000
+    relayer:
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc
 
   arbitrum:
     chain_name: "arbitrum"
@@ -164,6 +176,9 @@ chains:
       validator_announce_contract_address: "0x1df063280C4166AF9a725e3828b4dAC6c7113B08"
       merkle_hook_contract_address: "0xb49a14568f9CC440f2c7DCf7FC6766040a5eb860"
       mailbox_address: "0x979Ca5202784112f4738403dBec5D0F3B9daabB9"
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc
+
   arbitrum-testnet:
     chain_name: "arbitrum"
     chain_id: "421614"
@@ -183,6 +198,10 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: 250000000000000000
         critical_threshold_wei: 0
+    relayer:
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc
+
   osmosis:
     chain_name: "osmosis"
     chain_id: "osmosis-1"
@@ -244,6 +263,9 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: <warning_threshold_wei> # e.g. 180000000000000000
         critical_threshold_wei: <critical_threshold_wei> # e.g. 60000000000000000
+    relayer:
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc
 
   polygon:
     chain_name: "polygon"
@@ -270,4 +292,8 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: <warning_threshold_wei> # e.g. 15000000000000000000
         critical_threshold_wei: <critical_threshold_wei> # e.g. 5000000000000000000
-      min_gas_tip_cap: 30000000000
+      gas_price: <gas_price> # e.g. "30000000000"
+      min_gas_tip_cap: <min_gas_tip_cap> # e.g. 30000000000
+    relayer:
+      profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
+      relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc

--- a/config/local/config.yml
+++ b/config/local/config.yml
@@ -293,7 +293,6 @@ chains:
         warning_threshold_wei: <warning_threshold_wei> # e.g. 15000000000000000000
         critical_threshold_wei: <critical_threshold_wei> # e.g. 5000000000000000000
       min_gas_tip_cap: 30000000000
-      gas_price: <gas_price> # e.g. "30000000000"
     relayer:
       profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
       relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc

--- a/config/local/config.yml
+++ b/config/local/config.yml
@@ -292,8 +292,8 @@ chains:
       signer_gas_balance:
         warning_threshold_wei: <warning_threshold_wei> # e.g. 15000000000000000000
         critical_threshold_wei: <critical_threshold_wei> # e.g. 5000000000000000000
+      min_gas_tip_cap: 30000000000
       gas_price: <gas_price> # e.g. "30000000000"
-      min_gas_tip_cap: <min_gas_tip_cap> # e.g. 30000000000
     relayer:
       profitable_relay_timeout: <profitability_relay_timeout> # e.g. "5m"
       relay_cost_cap_uusdc: <relay_cost_cap_uusdc> # e.g. "1000000" uusdc

--- a/ordersettler/ordersettler.go
+++ b/ordersettler/ordersettler.go
@@ -290,9 +290,11 @@ func (r *OrderSettler) relayBatch(
 		return fmt.Errorf("calculating max batch (hash: %s) tx fee in uusdc: %w", txHash, err)
 	}
 	if maxTxFeeUUSDC.Cmp(big.NewInt(0)) <= 0 {
-		return fmt.Errorf(
-			"batch max tx fee in uusdc is <= 0 based on configured profit margin for %s. min profit margin should be lowered based on current batch size and min fee bps",
-			settlementPayoutChainID,
+		lmt.Logger(ctx).Warn(
+			"max tx fee to maintain configured profit margin when relaying settlement is less than or equal to 0. this settlement will not be relayed until it is timed out. min profit margin should be lowered based on current batch size and min fee bps to settlements can be relayed",
+			zap.String("maxTxFeeUUSDC", maxTxFeeUUSDC.String()),
+			zap.String("settlementInitiationChainID", batch.DestinationChainID()),
+			zap.String("settlementPayoutChainID", batch.SourceChainID()),
 		)
 	}
 

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -218,6 +218,24 @@ type RelayerConfig struct {
 	// MailboxAddress is the address of the Hyperlane mailbox contract used
 	// for sending and receiving cross-chain messages
 	MailboxAddress string `yaml:"mailbox_address"`
+
+	// ProfitableRelayTimeout is the maximum amount of time delay relaying a
+	// transaction waiting for it to be profitable. Currently this only applies
+	// to settlement relays. For example, if you have your MinProfitMarginBPS
+	// set too high relative to current gas fees on the settle up chain, then
+	// the relay will be delayed indefinitely until the gas fees reach a
+	// certain level (which they may never reach). Once a tx has been attempted
+	// to be relayed for ProfitableRelayTimeout duration, but it hasnt been
+	// sent because it is not profitable, then it will be sent regardless of
+	// profitability. This can be set to -1 for no timeout.
+	ProfitableRelayTimeout time.Duration `yaml:"relay_timeout"`
+
+	// MaxRelayTxFeeUUSDC is the maximum amount of uusdc to pay to relay a tx,
+	// regardless of profitability checking, i.e. if the ProfitableRelayTimeout
+	// expires for a tx and it is going to be sent without ensuring it is
+	// profitable for the solver to do so, this is a final check to ensure that
+	// the tx is not relayed in an extremely expensive block.
+	MaxRelayTxFeeUUSDC string `yaml:"max_relay_tx_fee_uusdc"`
 }
 
 // Used to monitor gas balance prometheus metric per chain for the solver addresses

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -228,14 +228,14 @@ type RelayerConfig struct {
 	// to be relayed for ProfitableRelayTimeout duration, but it hasnt been
 	// sent because it is not profitable, then it will be sent regardless of
 	// profitability. This can be set to -1 for no timeout.
-	ProfitableRelayTimeout time.Duration `yaml:"relay_timeout"`
+	ProfitableRelayTimeout *time.Duration `yaml:"profitable_relay_timeout"`
 
-	// MaxRelayTxFeeUUSDC is the maximum amount of uusdc to pay to relay a tx,
+	// RelayCostCapUUSDC is the maximum amount of uusdc to pay to relay a tx,
 	// regardless of profitability checking, i.e. if the ProfitableRelayTimeout
 	// expires for a tx and it is going to be sent without ensuring it is
 	// profitable for the solver to do so, this is a final check to ensure that
 	// the tx is not relayed in an extremely expensive block.
-	MaxRelayTxFeeUUSDC string `yaml:"max_relay_tx_fee_uusdc"`
+	RelayCostCapUUSDC string `yaml:"relay_cost_cap_uusdc"`
 }
 
 // Used to monitor gas balance prometheus metric per chain for the solver addresses


### PR DESCRIPTION
If a solver sets their `min_fee_bps`, `batch_uusdc_settle_up_threshold` and `min_profit_margin_bps` for values that do not make sense for chains typical gas fees or for what fees the api is charging users to fast transfer, then they may end up with a max tx fee for a hyperlane transfer (settlement) that is impossible to satisfy based on a chains typical tx fees. 

This PR adds two new relayer config options to fix this potential issue:
* `profitable_relay_timeout`
* `relay_cost_cap_uusdc`

`profitable_relay_timeout` is the duration of time where the relayer will attempt to relay a tx profitably (based on the configured `min_fee_bps`, `batch_uusdc_settle_up_threshold` and `min_profit_margin_bps`). After this period expires, the relayer will use the `relay_cost_cap_uusdc` as the max tx fee to relay the transaction.

`relay_cost_cap_uusdc` is the max tx fee that the relayer will use to try and relay a tx (based on chain simulations, in practice it could be slightly higher if the simulation underestimates). When a relay with a profitability configuration times out based on `profitable_relay_timeout`, it will use `relay_cost_cap_uusdc` as the max tx fee. Additionally, if there is no profitability configuration for a relay (timeouts, since they do not carry any value), the `relay_cost_cap_uusdc` will always be used as the max tx fee.