### PR TITLE
Do not assume gas token is ethereum on every chain in price estimation

### DIFF
--- a/config/local/config.yml
+++ b/config/local/config.yml
@@ -36,6 +36,7 @@ chains:
     environment: "mainnet"
     gas_token_symbol: "ETH"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "ethereum"
     fast_transfer_contract_address: <use_address_from_readme>
     num_block_confirmations_before_fill: <num_block_confirmations_before_fill> # e.g. 1
     min_fill_size: <min_fill_size> # e.g. 5000000
@@ -65,6 +66,7 @@ chains:
     environment: "testnet"
     gas_token_symbol: "ETH"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "ethereum"
     fast_transfer_contract_address: <use_address_from_readme>
     num_block_confirmations_before_fill: <num_block_confirmations_before_fill> # e.g. 1
     min_fill_size: <min_fill_size> # e.g. 5000000
@@ -94,6 +96,7 @@ chains:
     environment: "mainnet"
     gas_token_symbol: "AVAX"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "avalanche-2"
     fast_transfer_contract_address: <use_address_from_readme>
     num_block_confirmations_before_fill: <num_block_confirmations_before_fill> # e.g. 1
     min_fill_size: <min_fill_size> # e.g. 5000000
@@ -123,6 +126,7 @@ chains:
     environment: "mainnet"
     gas_token_symbol: "ETH"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "ethereum"
     fast_transfer_contract_address: <use_address_from_readme>
     num_block_confirmations_before_fill: <num_block_confirmations_before_fill> # e.g. 1
     min_fill_size: <min_fill_size> # e.g. 5000000
@@ -152,6 +156,7 @@ chains:
     environment: "mainnet"
     gas_token_symbol: "ETH"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "ethereum"
     quick_start_num_blocks_back: 300000
     fast_transfer_contract_address: <use_address_from_readme>
     solver_address: <solver_address> # e.g. "0x8EB49E3D65d74967CC0Fe987FA2d015ae816352E"
@@ -186,6 +191,7 @@ chains:
     environment: "testnet"
     gas_token_symbol: "ETH"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "ethereum"
     #### SEE shared/config/config.go for guidance on how to set the below three values per chain ####
     min_fee_bps: <min_fee_bps> # e.g. 100
     batch_uusdc_settle_up_threshold: <batch_uusdc_settle_up_threshold> # e.g. 5000000
@@ -209,6 +215,7 @@ chains:
     environment: "mainnet"
     gas_token_symbol: "OSMO"
     gas_token_decimals: 6
+    gas_token_coingecko_id: "osmosis"
     fast_transfer_contract_address: <use_address_from_readme>
     solver_address: <solver_address>
     hyperlane_domain: "875"
@@ -245,6 +252,7 @@ chains:
     environment: "mainnet"
     gas_token_symbol: "ETH"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "ethereum"
     fast_transfer_contract_address: <use_address_from_readme>
     num_block_confirmations_before_fill: <num_block_confirmations_before_fill> # e.g. 1
     min_fill_size: <min_fill_size> # e.g. 5000000
@@ -274,6 +282,7 @@ chains:
     environment: "mainnet"
     gas_token_symbol: "MATIC"
     gas_token_decimals: 18
+    gas_token_coingecko_id: "matic-network"
     fast_transfer_contract_address: <use_address_from_readme>
     num_block_confirmations_before_fill: <num_block_confirmations_before_fill> # e.g. 1
     min_fill_size: <min_fill_size> # e.g. 5000000

--- a/hyperlane/relayer_runner.go
+++ b/hyperlane/relayer_runner.go
@@ -82,7 +82,7 @@ func (r *RelayerRunner) Run(ctx context.Context) error {
 						lmt.Logger(ctx).Warn(
 							"relaying transfer is too expensive, waiting for better conditions",
 							zap.String("sourceChainID", transfer.SourceChainID),
-							zap.String("sourceChainID", transfer.DestinationChainID),
+							zap.String("destChainID", transfer.DestinationChainID),
 							zap.String("txHash", transfer.MessageSentTx),
 						)
 					case errors.Is(err, ErrNotEnoughSignaturesFound):

--- a/hyperlane/relayer_runner.go
+++ b/hyperlane/relayer_runner.go
@@ -82,6 +82,7 @@ func (r *RelayerRunner) Run(ctx context.Context) error {
 						lmt.Logger(ctx).Warn(
 							"relaying transfer is too expensive, waiting for better conditions",
 							zap.String("sourceChainID", transfer.SourceChainID),
+							zap.String("sourceChainID", transfer.DestinationChainID),
 							zap.String("txHash", transfer.MessageSentTx),
 						)
 					case errors.Is(err, ErrNotEnoughSignaturesFound):

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -83,6 +83,8 @@ type ChainConfig struct {
 	GasTokenSymbol string `yaml:"gas_token_symbol"`
 	// GasTokenDecimals specifies the number of decimal places for the gas token
 	GasTokenDecimals uint8 `yaml:"gas_token_decimals"`
+	// GasTokenCoingeckoID is the coingecko ID of the chain's gas token
+	GasTokenCoingeckoID string `yaml:"gas_token_coingecko_id"`
 	// NumBlockConfirmationsBeforeFill is the number of block confirmations required
 	// before the solver will attempt to fill an order
 	NumBlockConfirmationsBeforeFill int64 `yaml:"num_block_confirmations_before_fill"`

--- a/shared/evmrpc/tx_price_oracle_test.go
+++ b/shared/evmrpc/tx_price_oracle_test.go
@@ -56,7 +56,7 @@ func Test_Oracle_TxFeeUUSDC(t *testing.T) {
 			mockcoingecko.EXPECT().GetSimplePrice(ctx, "ethereum", "usd").Return(tt.ETHPriceUSD, nil)
 
 			oracle := evmrpc.NewOracle(mockcoingecko)
-			uusdcPrice, err := oracle.TxFeeUUSDC(ctx, tx)
+			uusdcPrice, err := oracle.TxFeeUUSDC(ctx, tx, "ethereum")
 			assert.NoError(t, err)
 			assert.Equal(t, tt.ExpectedUUSDCPrice, uusdcPrice.Int64())
 		})


### PR DESCRIPTION
Updates tx cost estimation logic in profitability checks to consider the chain's native token, which is not always eth.