### PR TITLE
[API-3627]  Do not query logs for order details on source chain during settlement

### DIFF
--- a/ordersettler/ordersettler.go
+++ b/ordersettler/ordersettler.go
@@ -184,13 +184,11 @@ func (r *OrderSettler) findNewSettlements(ctx context.Context) error {
 				continue
 			}
 
-			orderDetails, err := sourceBridgeClient.QueryOrderSubmittedEvent(ctx, sourceGatewayAddress, fill.OrderID)
+			orderFillEvent, _, err := bridgeClient.QueryOrderFillEvent(ctx, chain.FastTransferContractAddress, fill.OrderID)
 			if err != nil {
-				return fmt.Errorf("getting order submitted event on chain %s for order %s: %w", sourceChainID, fill.OrderID, err)
-			} else if orderDetails == nil {
-				return fmt.Errorf("could not find order submitted event on chain %s for order %s", sourceChainID, fill.OrderID)
+				return fmt.Errorf("querying for order fill event on destination chain at address %s for order id %s: %w", chain.FastTransferContractAddress, fill.OrderID, err)
 			}
-			profit := big.NewInt(0).Sub(orderDetails.AmountIn, orderDetails.AmountOut)
+			profit := new(big.Int).Sub(amount, orderFillEvent.FillAmount)
 
 			_, err = r.db.InsertOrderSettlement(ctx, db.InsertOrderSettlementParams{
 				SourceChainID:                     sourceChainID,

--- a/shared/bridges/cctp/bridge_client.go
+++ b/shared/bridges/cctp/bridge_client.go
@@ -3,9 +3,10 @@ package cctp
 import (
 	"context"
 	"fmt"
-	"github.com/skip-mev/go-fast-solver/shared/contracts/fast_transfer_gateway"
 	"math/big"
 	"time"
+
+	"github.com/skip-mev/go-fast-solver/shared/contracts/fast_transfer_gateway"
 
 	"github.com/skip-mev/go-fast-solver/db/gen/db"
 	"github.com/skip-mev/go-fast-solver/ordersettler/types"
@@ -57,7 +58,7 @@ type BridgeClient interface {
 	InitiateBatchSettlement(ctx context.Context, batch types.SettlementBatch) (string, string, error)
 	IsSettlementComplete(ctx context.Context, gatewayContractAddress, orderID string) (bool, error)
 	OrderFillsByFiller(ctx context.Context, gatewayContractAddress, fillerAddress string) ([]Fill, error)
-	QueryOrderFillEvent(ctx context.Context, gatewayContractAddress, orderID string) (fillTx *string, filler *string, blockTimestamp time.Time, err error)
+	QueryOrderFillEvent(ctx context.Context, gatewayContractAddress, orderID string) (*OrderFillEvent, time.Time, error)
 	Balance(ctx context.Context, address, denom string) (*big.Int, error)
 	OrderExists(ctx context.Context, gatewayContractAddress, orderID string, blockNumber *big.Int) (exists bool, amount *big.Int, err error)
 	IsOrderRefunded(ctx context.Context, gatewayContractAddress, orderID string) (bool, string, error)

--- a/shared/bridges/cctp/evm_bridge_client.go
+++ b/shared/bridges/cctp/evm_bridge_client.go
@@ -205,8 +205,8 @@ func (c *EVMBridgeClient) IsOrderRefunded(ctx context.Context, gatewayContractAd
 	return false, "", nil
 }
 
-func (c *EVMBridgeClient) QueryOrderFillEvent(ctx context.Context, gatewayContractAddress, orderID string) (*string, *string, time.Time, error) {
-	return nil, nil, time.Time{}, errors.New("not implemented")
+func (c *EVMBridgeClient) QueryOrderFillEvent(ctx context.Context, gatewayContractAddress, orderID string) (*OrderFillEvent, time.Time, error) {
+	return nil, time.Time{}, errors.New("not implemented")
 }
 
 func (c *EVMBridgeClient) ShouldRetryTx(ctx context.Context, txHash string, submitTime pgtype.Timestamp, txExpirationHeight *uint64) (bool, error) {


### PR DESCRIPTION
This should fix an error that a solver was receiving during settlement. They are using a free tier alchemy node that does not allow for an eth_getLogs query for 10k blocks. This call was done during settlement to get order details from the source chain in order to calculate profit. I changed to instead query the destination chain via a /tx_search to find the tx hash of the order fill, and then parse the order fill amount from the tx events.

Additionally, this fixes a TODO that we had outstanding where the query order fill event function was returning a hardcoded tx hash instead of the actual tx hash of the fill.