### PR TITLE
add retry logic for hyperlane relay

### DIFF
--- a/hyperlane/relayer_runner.go
+++ b/hyperlane/relayer_runner.go
@@ -21,7 +21,6 @@ import (
 const (
 	relayInterval                  = 10 * time.Second
 	excessiveHyperlaneRelayLatency = 30 * time.Minute
-	relayRetryInterval             = 1 * time.Minute
 )
 
 type Database interface {

--- a/hyperlane/relayer_runner.go
+++ b/hyperlane/relayer_runner.go
@@ -5,10 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/skip-mev/go-fast-solver/shared/metrics"
 	"math/big"
 	"strings"
 	"time"
+
+	"github.com/skip-mev/go-fast-solver/shared/metrics"
 
 	dbtypes "github.com/skip-mev/go-fast-solver/db"
 	"github.com/skip-mev/go-fast-solver/db/gen/db"
@@ -20,6 +21,7 @@ import (
 const (
 	relayInterval                  = 10 * time.Second
 	excessiveHyperlaneRelayLatency = 30 * time.Minute
+	relayRetryInterval             = 1 * time.Minute
 )
 
 type Database interface {
@@ -210,16 +212,27 @@ func (r *RelayerRunner) checkHyperlaneTransferStatus(ctx context.Context, transf
 		metrics.FromContext(ctx).IncHyperlaneMessages(transfer.SourceChainID, transfer.DestinationChainID, dbtypes.TransferStatusAbandoned)
 		metrics.FromContext(ctx).ObserveHyperlaneLatency(transfer.SourceChainID, transfer.DestinationChainID, dbtypes.TransferStatusAbandoned, time.Since(transfer.CreatedAt))
 
-		// for now we will not attempt to submit the hyperlane message more than once.
-		// this is to avoid the gas cost of repeatedly landing a failed hyperlane delivery tx.
-		// in the future we may add more sophistication around retries
+		lastAttempt := txs[len(txs)-1]
+		if time.Since(lastAttempt.CreatedAt) > relayRetryInterval {
+			lmt.Logger(ctx).Info(
+				"attempting to retry delivery of hyperlane message",
+				zap.String("sourceChainID", transfer.SourceChainID),
+				zap.String("destinationChainID", transfer.DestinationChainID),
+				zap.String("messageID", transfer.MessageID),
+				zap.String("previousAttemptTxHash", lastAttempt.TxHash),
+			)
+
+			return true, nil
+		}
+
 		lmt.Logger(ctx).Info(
-			"delivery attempt already made for message",
+			"delivery attempt already made for message, waiting for retry interval to pass",
 			zap.String("sourceChainID", transfer.SourceChainID),
 			zap.String("destinationChainID", transfer.DestinationChainID),
 			zap.String("messageID", transfer.MessageID),
 			zap.String("deliveryAttemptTxHash", txs[0].TxHash),
 		)
+
 		return false, nil
 	}
 

--- a/shared/bridges/cctp/bridge_client.go
+++ b/shared/bridges/cctp/bridge_client.go
@@ -50,6 +50,14 @@ func (e ErrReceiveNotFound) Error() string {
 	return fmt.Sprintf("receive not found for tx: %s", e.TxHash)
 }
 
+type ErrTxResultNotFound struct {
+	TxHash string
+}
+
+func (e ErrTxResultNotFound) Error() string {
+	return fmt.Sprintf("tx result not found for tx: %s", e.TxHash)
+}
+
 type BridgeClient interface {
 	BlockHeight(ctx context.Context) (uint64, error)
 	SignerGasTokenBalance(ctx context.Context) (*big.Int, error)

--- a/shared/bridges/cctp/cosmos_bridge_client.go
+++ b/shared/bridges/cctp/cosmos_bridge_client.go
@@ -167,6 +167,9 @@ func (c *CosmosBridgeClient) GetTxResult(ctx context.Context, txHash string) (*b
 
 	result, err := c.rpcClient.Tx(ctx, txHashBytes, false)
 	if err != nil {
+		if strings.HasSuffix(err.Error(), "not found") {
+			return nil, nil, ErrTxResultNotFound{TxHash: txHash}
+		}
 		return nil, nil, err
 	} else if result.TxResult.Code != 0 {
 		return big.NewInt(result.TxResult.GasUsed), &TxFailure{fmt.Sprintf("tx failed with code: %d and log: %s", result.TxResult.Code, result.TxResult.Log)}, nil

--- a/shared/bridges/cctp/evm_bridge_client.go
+++ b/shared/bridges/cctp/evm_bridge_client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -91,6 +92,10 @@ func (c *EVMBridgeClient) InitiateTimeout(ctx context.Context, order db.Order, g
 func (c *EVMBridgeClient) GetTxResult(ctx context.Context, txHash string) (*big.Int, *TxFailure, error) {
 	receipt, err := c.client.TransactionReceipt(ctx, common.HexToHash(txHash))
 	if err != nil {
+		if errors.Is(err, ethereum.NotFound) {
+			return nil, nil, ErrTxResultNotFound{TxHash: txHash}
+		}
+
 		return nil, nil, err
 	}
 	if receipt == nil {

--- a/txverifier/txverifier.go
+++ b/txverifier/txverifier.go
@@ -19,7 +19,7 @@ import (
 	"github.com/skip-mev/go-fast-solver/shared/lmt"
 )
 
-var (
+const (
 	txAbandonedTimeout = 10 * time.Minute
 )
 

--- a/txverifier/txverifier.go
+++ b/txverifier/txverifier.go
@@ -3,10 +3,12 @@ package txverifier
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	dbtypes "github.com/skip-mev/go-fast-solver/db"
+	"github.com/skip-mev/go-fast-solver/shared/bridges/cctp"
 	"github.com/skip-mev/go-fast-solver/shared/clientmanager"
 	"github.com/skip-mev/go-fast-solver/shared/metrics"
 
@@ -15,6 +17,10 @@ import (
 
 	"github.com/skip-mev/go-fast-solver/db/gen/db"
 	"github.com/skip-mev/go-fast-solver/shared/lmt"
+)
+
+var (
+	txAbandonedTimeout = 10 * time.Minute
 )
 
 type Config struct {
@@ -94,6 +100,10 @@ func (r *TxVerifier) VerifyTx(ctx context.Context, submittedTx db.SubmittedTx) e
 	}
 	_, failure, err := bridgeClient.GetTxResult(ctx, submittedTx.TxHash)
 	if err != nil {
+		if errors.As(err, &cctp.ErrTxResultNotFound{}) {
+			return r.handleTxResultNotFound(ctx, submittedTx)
+		}
+
 		return fmt.Errorf("failed to get tx result: %w", err)
 	} else if failure != nil {
 		lmt.Logger(ctx).Error("tx failed", zap.String("failure", failure.String()))
@@ -117,5 +127,19 @@ func (r *TxVerifier) VerifyTx(ctx context.Context, submittedTx db.SubmittedTx) e
 			return fmt.Errorf("failed to set tx status to success: %w", err)
 		}
 	}
+	return nil
+}
+
+func (r *TxVerifier) handleTxResultNotFound(ctx context.Context, submittedTx db.SubmittedTx) error {
+	if time.Since(submittedTx.CreatedAt) > txAbandonedTimeout {
+		if _, err := r.db.SetSubmittedTxStatus(ctx, db.SetSubmittedTxStatusParams{
+			TxStatus: dbtypes.TxStatusAbandoned,
+			TxHash:   submittedTx.TxHash,
+			ChainID:  submittedTx.ChainID,
+		}); err != nil {
+			return fmt.Errorf("failed to set tx status to abandoned: %w", err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Adds logic to retry delivery of a Hyperlane message if a previous attempt has not landed on chain after a configured amount of time (I set it to 1 minute, let me know if there's a more appropriate value).