### PR TITLE
[API-4166] batch settlement count threshold

### DIFF
--- a/config/sample/config.yml
+++ b/config/sample/config.yml
@@ -89,6 +89,7 @@ chains:
     batch_uusdc_settle_up_threshold: <batch_uusdc_settle_up_threshold> # e.g. 5000000
     min_profit_margin_bps: <min_profit_margin_bps> # e.g. 50
     settlement_rebatch_timeout: 1h
+    batch_settlement_count_threshold: 10
     evm:
       rpc: <ethereum_rpc_server_url> # e.g. "https://eth.llamarpc.com"
       rpc_basic_auth_var: <server_password>

--- a/ordersettler/ordersettler.go
+++ b/ordersettler/ordersettler.go
@@ -454,8 +454,8 @@ func (r *OrderSettler) ShouldInitiateSettlement(ctx context.Context, batch types
 			err,
 		)
 	}
-
-	return value.Cmp(settlementThreshold) >= 0, nil
+	exceedsBatchSettlementCountThreshold := sourceChainConfig.BatchSettlementCountThreshold > 0 && len(batch.OrderIDs()) >= sourceChainConfig.BatchSettlementCountThreshold
+	return value.Cmp(settlementThreshold) >= 0 || exceedsBatchSettlementCountThreshold, nil
 }
 
 // SettleBatches tries to settle a list settlement batches and update the

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -227,6 +227,15 @@ type ChainConfig struct {
 	// existing settlement will have its relay cancelled. It will then be batched with
 	// the newer settlement in a new initiate settlement transaction.
 	SettlementRebatchTimeout time.Duration `yaml:"settlement_rebatch_timeout"`
+
+	// If there are a number of pending settlements for a chain that is greater than or equal to
+	// BatchSettlementCountThreshold, the solver will initiate a batch settlement. This prevents a situation where a
+	// solver accumulates a large number of settlements while gas is low and then is unable to settle them when gas price
+	// spikes. Even if they fill new orders at the higher gas prices which have a larger fee attached, there can be
+	// so many accumulated settlements, that the larger fee cannot fully subsidize the settlement costs for the batch.
+	// Thus we set a number for BatchSettlementCountThreshold to prevent the accumulation of a large number of pending
+	// settlements.
+	BatchSettlementCountThreshold int `yaml:"batch_settlement_count_threshold"`
 }
 
 type RelayerConfig struct {


### PR DESCRIPTION
The goal of this PR is to avoid an edge case where if a solver accumulates a large number of settlements at a low gas price, they may be unable to complete the settlements if gas spikes for a prolonged time. It adds logic to keep the number of pending settlements from becoming excessive.

- Adds a `batch_settlement_count_threshold` config 
- If the number of pending settlements for a chain exceeds this config value, a settlement is initiated.
