### PR TITLE
[API-4244] Only Fill DyDx GoFast Orders

### DIFF
--- a/config/sample/config.yml
+++ b/config/sample/config.yml
@@ -217,6 +217,7 @@ chains:
         critical_threshold_wei: <critical_threshold_wei> # e.g. 14290000
       gas_price: 0.0025
       gas_denom: "uosmo"
+      only_fill_dydx_orders: false
     relayer:
       validator_announce_contract_address: "osmo147r8mfdsngswujgkr4tln9rhcrzz6yq0xn448ksd96mlcmp9wg6stvznke"
       merkle_hook_contract_address: "osmo1e765uc5mctl7rz8dzl9decl5ghgxggeqyxutkjp2xkggrg6zma3qgdq2g4"

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -303,6 +303,9 @@ type CosmosConfig struct {
 	// MaxFillSize is the maximum amount of USDC that can be processed in a single
 	// order fill. Orders exceeding this size will be abandoned
 	MaxFillSize *big.Int `yaml:"max_fill_size"`
+	// If OnlyFillDyDxOrders is true, the solver will only fill orders that have DyDx
+	// as the final transfer destination
+	OnlyFillDyDxOrders bool `yaml:"only_fill_dydx_orders"`
 }
 
 type EVMConfig struct {


### PR DESCRIPTION
- adds order filling logic that will only fill orders with DyDx as the final transfer destination
- adds config to toggle the above behavior on/off

I didn't really spend any time thinking about a more general solution. We can generalize this logic if we want to enable other fee subsidy programs in the future.