### PR TITLE
ci: pin gitops-actions to v0.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           matrix-step-name: github-action-matrix-outputs-read
       - name: Update the image tags
-        uses: skip-mev/gitops-actions/update-values@main
+        uses: skip-mev/gitops-actions/update-values@v0.0.1
         with:
           service: "solver"
           app_id: ${{ vars.DEPLOYER_APP_ID }}


### PR DESCRIPTION
Pins all `skip-mev/gitops-actions` references in this repo's workflows to `@v0.0.1` 