### PR TITLE
ECR Image Redundancy — Dual-Push to New CLK AWS Dev Account

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           aws ecr describe-repositories --region us-east-2 --repository-names $repo_name || aws ecr create-repository --repository-name $repo_name --region us-east-2
       - name: Configure AWS Credentials (new CLK Dev ECR)
-        uses: aws-actions/configure-aws-credentials$v4.0.2
+        uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           aws-region: us-east-2
           role-session-name: ${{ github.run_id }}-new

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     env:
       registry_url: 494494944992.dkr.ecr.us-east-2.amazonaws.com/skip-mev/${{ matrix.image.name }}
+      clk_dev_registry_url: 894792044932.dkr.ecr.us-east-2.amazonaws.com/skip-mev/${{ matrix.image.name }}
       repo_name: skip-mev/${{ matrix.image.name }}
     steps:
       - name: Check out the PR commit head
@@ -38,6 +40,20 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+      - name: Create ECR repository if it does not exist
+        run: |
+          aws ecr describe-repositories --region us-east-2 --repository-names $repo_name || aws ecr create-repository --repository-name $repo_name --region us-east-2
+      - name: Configure AWS Credentials (new CLK Dev ECR)
+        uses: aws-actions/configure-aws-credentials$v4.0.2
+        with:
+          aws-region: us-east-2
+          role-session-name: ${{ github.run_id }}-new
+          role-to-assume: arn:aws:iam::894792044932:role/GithubImagePusher
+      - name: Login to Amazon ECR (new CLK Dev ECR)
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Create ECR repository if it does not exist (new CLK Dev ECR)
+        run: |
+          aws ecr describe-repositories --region us-east-2 --repository-names $repo_name || aws ecr create-repository --repository-name $repo_name --region us-east-2
       - name: Log in to the Container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
@@ -48,9 +64,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Create ECR repository if it does not exist
-        run: |
-          aws ecr describe-repositories --region us-east-2 --repository-names $repo_name || aws ecr create-repository --repository-name $repo_name --region us-east-2
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -60,6 +73,7 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             ${{ env.registry_url }}
+            ${{ env.clk_dev_registry_url }}
             ghcr.io/skip-mev/${{ matrix.image.name }}
           tags: |
             type=ref,event=pr


### PR DESCRIPTION
## What's changing

**Short Term**: CI build workflows currently push Docker images only to the legacy CL AWS account's ECR (`AtlantisAdmin`). We're updating these workflows so images are also pushed to the new CLK-owned AWS Dev account ECR (`skip-dev`), giving us redundant storage across both accounts.
**Long Term**: After completing the whole migration process, we'll remove the legacy CL AWS account's ECR (`AtlantisAdmin`) and start full usage of CLK-owned ECR (`skip-dev`), followed by only pushing images into CLK ECR

## Status: Tested and verified
All changes have been validated on branch: `af/ci-new-dev/ecr`, and the dual-push to the new ECR works as expected. We're now ready to submit PR and merge these changes into main branch.

- Git action test run: https://github.com/skip-mev/skip-go-fast-solver/actions/runs/29989956979
- Linear: [SKP-30](https://linear.app/cosmoslabskr/issue/SKP-30/ecr-repository%EC%97%90-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%9D%B4%EC%A4%91%ED%99%94-%EC%A0%80%EC%9E%A5)
---

```
 Changes to be committed:
	modified:   .github/workflows/build.yml
```